### PR TITLE
Add Robotnik's default jenkinsfile config

### DIFF
--- a/.github/Jenkinsfile
+++ b/.github/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPackage()


### PR DESCRIPTION
This pull request includes a small change to the `.github/Jenkinsfile`. The change adds a call to the `buildPackage` function.